### PR TITLE
Add a Danger check to prevent review approval for cops that have become `Enabled: true`

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,22 @@
+name: Danger
+on:
+  - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  danger:
+    name: Danger
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: "3.2"
+      - name: Run Danger
+        run: bundle exec danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+diff = git.diff_for_file('config/default.yml')
+if diff && diff.patch =~ /^\+\s*Enabled: true$/
+  warn(<<~MESSAGE)
+    There is a cop that became `Enabled: true`` due to this pull request.
+    Please review the diff and make sure there are no issues.
+  MESSAGE
+end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump'
+gem 'danger'
 gem 'rack'
 gem 'rake'
 gem 'rspec', '~> 3.11'


### PR DESCRIPTION
…

I suggest adding checks with Danger as a preventive measure against recurrence.

Resolve: https://github.com/rubocop/rubocop-rspec/pull/1613#issuecomment-1497696573

**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
